### PR TITLE
Fix critical log bug

### DIFF
--- a/src/battery_voltage_log.py
+++ b/src/battery_voltage_log.py
@@ -36,7 +36,7 @@ class BatteryVoltageLog():
         bat_volt = round(self.battery_pin.voltage() * config.BATTERY_VOLTAGE_CORRECTION_FACTOR, 1)
         if 24 < bat_volt < 29.4:
             self.bat_logger.info("%sv", bat_volt)
-        if 22 > bat_volt <= 24:
+        elif 22 < bat_volt <= 24:
             self.bat_logger.warning("%sv", bat_volt)
             root_logger.warning("Battery voltage: %sv", bat_volt)
         else:


### PR DESCRIPTION
else condition was only attached to the second 'if' statement. So critical log was always printing with info level logs.
To make all three attached then it should follow following structure.
if <condition>:
elif <condition>:
elif<condition>:
else: